### PR TITLE
Adding support for standard sharing panel for Issue #19

### DIFF
--- a/Classes/WDCanvasController.h
+++ b/Classes/WDCanvasController.h
@@ -40,7 +40,8 @@ enum {
 };
 
 @interface WDCanvasController : UIViewController <UINavigationControllerDelegate, UIImagePickerControllerDelegate,
-                                                    MFMailComposeViewControllerDelegate, UIPopoverControllerDelegate>
+                                                    MFMailComposeViewControllerDelegate, UIPopoverControllerDelegate,
+                                                    UIDocumentInteractionControllerDelegate>
 {
     WDDocument          *document_;
     WDCanvas            *canvas_;
@@ -77,12 +78,15 @@ enum {
     
     WDHueSaturationController   *hueController_;
     WDColorBalanceController   *balanceController_;
+
+    NSURL *exportFileUrl;
 }
 
 @property (nonatomic, strong) WDDocument *document;
 @property (weak, nonatomic, readonly) WDDrawing *drawing;
 @property (nonatomic, readonly) WDCanvas *canvas;
 @property (nonatomic, readonly, strong) WDDrawingController *drawingController;
+@property (strong, nonatomic) UIDocumentInteractionController *documentInteractionController;
 
 - (void) updateTitle;
 - (void) hidePopovers;

--- a/Classes/WDCanvasController.h
+++ b/Classes/WDCanvasController.h
@@ -10,7 +10,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import <MessageUI/MFMailComposeViewController.h>
 #import "WDElement.h"
 #import "WDStrokeStyle.h"
 
@@ -40,7 +39,7 @@ enum {
 };
 
 @interface WDCanvasController : UIViewController <UINavigationControllerDelegate, UIImagePickerControllerDelegate,
-                                                    MFMailComposeViewControllerDelegate, UIPopoverControllerDelegate,
+                                                    UIPopoverControllerDelegate,
                                                     UIDocumentInteractionControllerDelegate>
 {
     WDDocument          *document_;

--- a/Classes/WDCanvasController.m
+++ b/Classes/WDCanvasController.m
@@ -241,20 +241,6 @@
         
         [menus addObject:[WDMenuItem separatorItem]];
         
-        item = [WDMenuItem itemWithTitle:NSLocalizedString(@"Email as PNG", @"Email as PNG")
-                                  action:@selector(emailPNG:) target:self];
-        [menus addObject:item];
-        
-        item = [WDMenuItem itemWithTitle:NSLocalizedString(@"Email as PDF", @"Email as PDF")
-                                  action:@selector(emailPDF:) target:self];
-        [menus addObject:item];
-        
-        item = [WDMenuItem itemWithTitle:NSLocalizedString(@"Email as SVG", @"Email as SVG")
-                                  action:@selector(emailSVG:) target:self];
-        [menus addObject:item];
-
-        [menus addObject:[WDMenuItem separatorItem]];
-
         item = [WDMenuItem itemWithTitle:NSLocalizedString(@"Export as PNG", @"Export as PNG")
                                   action:@selector(exportAsPNG:) target:self];
         [menus addObject:item];
@@ -713,12 +699,7 @@
     }
     
     // ACTION
-    else if (item.action == @selector(emailPNG:) ||
-             item.action == @selector(emailPDF:) ||
-             item.action == @selector(emailSVG:))
-    {
-        item.enabled = [MFMailComposeViewController canSendMail];
-    } else if (item.action == @selector(printDrawing:)) {
+    else if (item.action == @selector(printDrawing:)) {
         item.enabled = [UIPrintInteractionController isPrintingAvailable];
     }
     
@@ -1451,46 +1432,6 @@
     [self presentViewController:tweetSheet animated:YES completion:nil];
 }
 
-// Dismisses the email composition interface when users tap Cancel or Send. Proceeds to update the message field with the result of the operation.
-- (void)mailComposeController:(MFMailComposeViewController*)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError*)error 
-{	
-	[self.navigationController dismissViewControllerAnimated:YES completion:nil];
-}
-
-- (void) emailDrawing:(id)sender format:(NSString *)format
-{
-    MFMailComposeViewController *picker = [[MFMailComposeViewController alloc] init];
-    picker.mailComposeDelegate = self;
-    
-    NSString *baseFilename = [self.document.filename stringByDeletingPathExtension];
-    NSString *subject = NSLocalizedString(@"Inkpad Drawing: ", @"Inkpad Drawing: ");
-    subject = [subject stringByAppendingString:baseFilename];
-    [picker setSubject:subject];    
-    
-    NSData *data = nil;
-    NSString *mimetype = nil;
-    NSString *filename = nil;
-    
-    // Attach an image to the email
-    if ([format isEqualToString:@"PNG"]) {
-        data = UIImagePNGRepresentation([canvas_.drawing image]);
-        mimetype = @"image/png";
-        filename = [baseFilename stringByAppendingPathExtension:@"png"];
-    } else if ([format isEqualToString:@"PDF"]) {
-        data = [self.drawing PDFRepresentation];
-        mimetype = @"image/pdf";
-        filename = [baseFilename stringByAppendingPathExtension:@"pdf"];
-    } else if ([format isEqualToString:@"SVG"]) {
-        data = [self.drawing SVGRepresentation];
-        mimetype = @"image/svg+xml";
-        filename = [baseFilename stringByAppendingPathExtension:@"svg"];
-    } 
-    
-    [picker addAttachmentData:data mimeType:mimetype fileName:filename];
-    
-    [self.navigationController presentViewController:picker animated:YES completion:nil];
-}
-
 - (void) copyDrawing:(id)sender
 {
     [UIPasteboard generalPasteboard].image = [canvas_.drawing image];
@@ -1504,21 +1445,6 @@
     [UIView setAnimationDuration:1.0f];
     [UIView setAnimationTransition:UIViewAnimationTransitionCurlUp forView:canvas_ cache:YES];
     [UIView commitAnimations];
-}
-
-- (void) emailPNG:(id)sender
-{
-    [self emailDrawing:sender format:@"PNG"];
-}
-
-- (void) emailPDF:(id)sender
-{
-    [self emailDrawing:sender format:@"PDF"];
-}
-
-- (void) emailSVG:(id)sender
-{
-    [self emailDrawing:sender format:@"SVG"];
 }
 
 - (void) export:(id)sender format:(NSString *)format

--- a/Classes/WDCanvasController.m
+++ b/Classes/WDCanvasController.m
@@ -1454,13 +1454,13 @@
 
     // Generates export file in requested format
     if ([format isEqualToString:@"PDF"]) {
-        filename = [NSHomeDirectory() stringByAppendingPathComponent:[@"Documents/" stringByAppendingString:[baseFilename stringByAppendingPathExtension:@"pdf"]]];
+        filename = [NSTemporaryDirectory() stringByAppendingPathComponent:[baseFilename stringByAppendingPathExtension:@"pdf"]];
         [[self.drawing PDFRepresentation] writeToFile:filename atomically:YES];
     } else if ([format isEqualToString:@"PNG"]) {
-        filename = [NSHomeDirectory() stringByAppendingPathComponent:[@"Documents/" stringByAppendingString:[baseFilename stringByAppendingPathExtension:@"png"]]];
+        filename = [NSTemporaryDirectory() stringByAppendingPathComponent:[baseFilename stringByAppendingPathExtension:@"png"]];
         [UIImagePNGRepresentation([canvas_.drawing image]) writeToFile:filename atomically:YES];
     } else if ([format isEqualToString:@"SVG"]) {
-        filename = [NSHomeDirectory() stringByAppendingPathComponent:[@"Documents/" stringByAppendingString:[baseFilename stringByAppendingPathExtension:@"svg"]]];
+        filename = [NSTemporaryDirectory() stringByAppendingPathComponent:[baseFilename stringByAppendingPathExtension:@"svg"]];
         [[self.drawing SVGRepresentation] writeToFile:filename atomically:YES];
     }
 


### PR DESCRIPTION
First pass at answering issue #19.

One issue with this patch is that adding UIDocumentInteractionController duplicates a bunch of the options on the action menu already (printing / emailing / posting to Twitter / posting to Facebook). They could probably be removed, although you'd lose the ability to set things like initial text on Twitter postings and subject on emails because UIDocumentInteractionController doesn't seem to allow that.

Please let me know if you'd like an updated patch removing the duplicated options. I'll happily update the code.
