### PR TITLE
Add SVG to list of document types.

### DIFF
--- a/Inkpad-Info.plist
+++ b/Inkpad-Info.plist
@@ -20,6 +20,29 @@
 				<string>com.taptrix.inkpad</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>SVG Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.svg-image</string>
+			</array>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>svg</string>
+				<string>SVG</string>
+			</array>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>image/svg+xml</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<false/>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>


### PR DESCRIPTION
For Issue #31 Registering Inkpad as a handler for SVG files. WSAppDelegate already knows what to do when passed an SVG file so this seems to be all that is needed for Inkpad to handle SVG files passed from other applications.
