### PR TITLE
Fix for CTFontRef leak in WDFontManager.m

### DIFF
--- a/Classes/WDFontManager.m
+++ b/Classes/WDFontManager.m
@@ -210,6 +210,7 @@ NSString *WDFontAddedNotification = @"WDFontAddedNotification";
     for (NSString *fontName in sorted) {
         CTFontRef fontRef = [self newFontRefForFont:fontName withSize:10];
         CTFontSymbolicTraits traits = CTFontGetSymbolicTraits(fontRef);
+        CFRelease(fontRef);
         
         BOOL isBold = (traits & kCTFontBoldTrait);
         if (isBold) {


### PR DESCRIPTION
Was looking for something else and discovered this. Instruments shows objects leaking without this CFRelease, and then not leaking after the line is included.

BTW The Analysis tool in Xcode suggests another memory leak in WDUserFont.m but I'm not sure if it's correct. More experienced eyes might see something I'm missing though.
