### PR TITLE
Rewrite of WDBezierSegmentIsFlat

### DIFF
--- a/Inkpad-Core/Model/WDBezierSegment.h
+++ b/Inkpad-Core/Model/WDBezierSegment.h
@@ -39,7 +39,7 @@ BOOL WDBezierSegmentIntersectsRect(WDBezierSegment seg, CGRect rect);
 BOOL WDLineInRect(CGPoint a, CGPoint b, CGRect test);
 
 BOOL WDBezierSegmentIsStraight(WDBezierSegment segment);
-BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, float tolerance);
+BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, CGFloat tolerance);
 void WDBezierSegmentFlatten(WDBezierSegment seg, CGPoint **vertices, NSUInteger *size, NSUInteger *index);
 CGPoint WDBezierSegmentSplit(WDBezierSegment seg, WDBezierSegment *L, WDBezierSegment *R);
 CGPoint WDBezierSegmentSplitAtT(WDBezierSegment seg, WDBezierSegment *L, WDBezierSegment *R, float t);

--- a/Inkpad-Core/Model/WDBezierSegment.h
+++ b/Inkpad-Core/Model/WDBezierSegment.h
@@ -27,7 +27,12 @@ typedef struct {
 } WDBezierSegment;
 
 
-WDBezierSegment WDBezierSegmentMake(WDBezierNode *a, WDBezierNode *b);
+WDBezierSegment
+WDBezierSegmentMakeWithNodes(WDBezierNode *a, WDBezierNode *b);
+WDBezierSegment
+WDBezierSegmentMakeWithQuadPoints(CGPoint a, CGPoint c, CGPoint b);
+
+
 BOOL WDBezierSegmentIsDegenerate(WDBezierSegment seg);
 
 BOOL WDBezierSegmentIntersectsRect(WDBezierSegment seg, CGRect rect);

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -35,26 +35,40 @@ WDBezierSegment WDBezierSegmentMake(WDBezierNode *a, WDBezierNode *b)
     return segment;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+static inline CGPoint CGPointMin(CGPoint P1, CGPoint P2)
+{ return (CGPoint){ MIN(P1.x, P2.x), MIN(P1.y, P2.y) }; }
+
+static inline CGPoint CGPointMax(CGPoint P1, CGPoint P2)
+{ return (CGPoint){ MAX(P1.x, P2.x), MAX(P1.y, P2.y) }; }
+
 inline BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, float tolerance)
 {
-    float scaledTolerance = tolerance / [UIScreen mainScreen].scale;
-    
-    if (CGPointEqualToPoint(seg.a_, seg.out_) && CGPointEqualToPoint(seg.in_, seg.b_)) {
-        return YES;
-    }
-    
-    float dx = seg.b_.x - seg.a_.x;
-    float dy = seg.b_.y - seg.a_.y;
-    
-    float d2 = fabs((seg.out_.x - seg.b_.x) * dy - (seg.out_.y - seg.b_.y) * dx);
-    float d3 = fabs((seg.in_.x - seg.b_.x) * dy - (seg.in_.y - seg.b_.y) * dx);
+    if (CGPointEqualToPoint(seg.a_, seg.out_) &&
+		CGPointEqualToPoint(seg.in_, seg.b_))
+		return YES;
 
-    if ((d2 + d3) * (d2 + d3) <= scaledTolerance * (dx * dx + dy * dy)) {
-        return YES;
-    }
-    
-    return NO;
+	// Compute bounding box (WDBezierSegmentGetSimpleBounds)
+	CGPoint min = CGPointMin(seg.a_, seg.out_);
+	CGPoint max = CGPointMax(seg.a_, seg.out_);
+	min = CGPointMin(min, seg.in_);
+	max = CGPointMax(max, seg.in_);
+	min = CGPointMin(min, seg.b_);
+	max = CGPointMax(max, seg.b_);
+
+	// Get bounding box size
+	CGFloat dx = max.x - min.x;
+	CGFloat dy = max.y - min.y;
+
+    float scaledTolerance = tolerance / [UIScreen mainScreen].scale;
+
+	return
+	(dx <= scaledTolerance)&&
+	(dy <= scaledTolerance);
 }
+
+////////////////////////////////////////////////////////////////////////////////
 
 BOOL WDBezierSegmentIsDegenerate(WDBezierSegment seg)
 {

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -618,6 +618,9 @@ float WDBezierSegmentOutAngle(WDBezierSegment seg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+#pragma mark BezierCurve 
+////////////////////////////////////////////////////////////////////////////////
 
 static inline double _ComputeValueAtT
 	(double P0, double P1, double P2, double P3, double t)
@@ -634,7 +637,7 @@ static inline double _ComputeValueAtT
 
 ////////////////////////////////////////////////////////////////////////////////
 
-inline CGPoint WDBezierSegmentCalculatePointAtT(WDBezierSegment seg, float t)
+static inline double WDBezierSegmentComputeX(WDBezierSegment seg, float t)
 {
 	// Get Bezier co-efficients
 	double X0 = seg.a_.x;
@@ -643,8 +646,13 @@ inline CGPoint WDBezierSegmentCalculatePointAtT(WDBezierSegment seg, float t)
 	double X3 = seg.b_.x;
 
 	// Compute x coordinate for t
-	double x = _ComputeValueAtT(X0, X1, X2, X3, t);
+	return _ComputeValueAtT(X0, X1, X2, X3, t);
+}
 
+////////////////////////////////////////////////////////////////////////////////
+
+static inline double WDBezierSegmentComputeY(WDBezierSegment seg, float t)
+{
 	// Get Bezier co-efficients
 	double Y0 = seg.a_.y;
 	double Y1 = seg.out_.y;
@@ -652,12 +660,20 @@ inline CGPoint WDBezierSegmentCalculatePointAtT(WDBezierSegment seg, float t)
 	double Y3 = seg.b_.y;
 
 	// Compute y coordinate for t
-	double y = _ComputeValueAtT(Y0, Y1, Y2, Y3, t);
-
-	// Return result
-	return (CGPoint){ x, y };
+	return _ComputeValueAtT(Y0, Y1, Y2, Y3, t);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+inline CGPoint WDBezierSegmentCalculatePointAtT(WDBezierSegment seg, float t)
+{
+	return (CGPoint){
+	WDBezierSegmentComputeX(seg, t),
+	WDBezierSegmentComputeY(seg, t) };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
 ////////////////////////////////////////////////////////////////////////////////
 
 BOOL WDBezierSegmentGetIntersection(WDBezierSegment seg, CGPoint a, CGPoint b, float *tIntersect)

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -121,10 +121,10 @@ CGPoint WDBezierSegmentSplitAtT
 
 	CGPoint F = CGPointInterpolate(D, E, t);
 
-	if (L)
+	if (L != nil)
 	{ *L = WDBezierSegmentMakeWithPoints(seg.a_, A, D, F); }
 
-	if (R)
+	if (R != nil)
 	{ *R = WDBezierSegmentMakeWithPoints(F, E, C, seg.b_); }
 
 	return F;

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -45,7 +45,7 @@ static inline CGPoint CGPointMax(CGPoint P1, CGPoint P2)
 
 inline BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, float tolerance)
 {
-    if (CGPointEqualToPoint(seg.a_, seg.out_) &&
+	if (CGPointEqualToPoint(seg.a_, seg.out_) &&
 		CGPointEqualToPoint(seg.in_, seg.b_))
 		return YES;
 
@@ -61,11 +61,9 @@ inline BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, float tolerance)
 	CGFloat dx = max.x - min.x;
 	CGFloat dy = max.y - min.y;
 
-    float scaledTolerance = tolerance / [UIScreen mainScreen].scale;
-
 	return
-	(dx <= scaledTolerance)&&
-	(dy <= scaledTolerance);
+	(dx <= tolerance)&&
+	(dy <= tolerance);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -699,26 +699,37 @@ float WDBezierSegmentOutAngle(WDBezierSegment seg)
 
 inline CGPoint WDBezierSegmentCalculatePointAtT(WDBezierSegment seg, float t)
 {
-    float   t2 ,t3, td2, td3;
-    CGPoint result;
-    
-    t2 = t * t;
-    t3 = t2 * t;
-    
-    td2 = (1-t) * (1-t);
-    td3 = td2 * (1-t);
-    
-    result.x = td3 * seg.a_.x +
-    3 * t * td2 * seg.out_.x +
-    3 * t2 * (1-t) * seg.in_.x +
-    t3 * seg.b_.x;
-    
-    result.y = td3 * seg.a_.y +
-    3 * t * td2 * seg.out_.y +
-    3 * t2 * (1-t) * seg.in_.y +
-    t3 * seg.b_.y;
-    
-    return result;
+	// Get Bezier co-efficients
+	double X0 = seg.a_.x;
+	double X1 = seg.out_.x;
+	double X2 = seg.in_.x;
+	double X3 = seg.b_.x;
+
+	// Calculate polynomial co-efficients
+	double dx = X0;
+	double cx = 3*(X1-X0);
+	double bx = 3*(X2-X1) - cx;
+	double ax = (X3-X0) - bx - cx;
+
+	// Calculate polynomial result for t
+	double x = ((ax * t + bx) * t + cx) * t + dx;
+
+	// Get Bezier co-efficients
+	double Y0 = seg.a_.y;
+	double Y1 = seg.out_.y;
+	double Y2 = seg.in_.y;
+	double Y3 = seg.b_.y;
+
+	// Calculate polynomial co-efficients
+	double dy = Y0;
+	double cy = 3*(Y1-Y0);
+	double by = 3*(Y2-Y1) - cy;
+	double ay = (Y3-Y0) - by - cy;
+
+	// Calculate polynomial result for t
+	double y = ((ay * t + by) * t + cy) * t + dy;
+
+	return (CGPoint){ x, y };
 }
 
 BOOL WDBezierSegmentPointDistantFromPoint(WDBezierSegment seg, float distance, CGPoint pt, CGPoint *result, float *tResult)

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -13,7 +13,7 @@
 #import "WDBezierNode.h"
 #import "WDUtilities.h"
 
-const float kDefaultFlatness = 6;
+const float kDefaultFlatness = 1.5;
 
 static CGPoint      *vertices = NULL;
 static NSUInteger   size = 128;

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -23,7 +23,7 @@ float secondDerivative(float A, float B, float C, float D, float t);
 float base3(double t, double p1, double p2, double p3, double p4);
 float cubicF(double t, WDBezierSegment seg);
 
-WDBezierSegment WDBezierSegmentMake(WDBezierNode *a, WDBezierNode *b)
+WDBezierSegment WDBezierSegmentMakeWithNodes(WDBezierNode *a, WDBezierNode *b)
 {
     WDBezierSegment segment;
     
@@ -50,34 +50,34 @@ WDBezierSegmentMakeWithQuadPoints(CGPoint a, CGPoint c, CGPoint b)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/*
+	WDBezierSegmentIsFlat
+	---------------------
+	Check whether segment can be approximated by a line between endpoints.
+	
+	Suppose we have a horizontal line with tangential controlpoints 
+	at both ends with length r, then the curve deviates at most
+	(3.0/4.0) * r from a straight line. Thus, a 1 pixel tolerance means
+	that the vectors should be within r <= (4.0/3.0) * tolerance
 
-static inline CGPoint CGPointMin(CGPoint P1, CGPoint P2)
-{ return (CGPoint){ MIN(P1.x, P2.x), MIN(P1.y, P2.y) }; }
+	For simplicity and speed it would be nice if we could only check 
+	the euclidian vector coordinates against tolerance. This introduces 
+	an additional error for the worst case scenario (a diagonal line
+	at 45degr angle). To compensate this additional error,
+	tolerance should be divided by sqrt(2). 
+	
+	Conveniently: tolerance * (4.0/3.0) / sqrt(2) = ~tolerance
 
-static inline CGPoint CGPointMax(CGPoint P1, CGPoint P2)
-{ return (CGPoint){ MAX(P1.x, P2.x), MAX(P1.y, P2.y) }; }
+*/
 
-inline BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, float tolerance)
+inline BOOL WDBezierSegmentIsFlat(WDBezierSegment seg, CGFloat deviceTolerance)
 {
-	if (CGPointEqualToPoint(seg.a_, seg.out_) &&
-		CGPointEqualToPoint(seg.in_, seg.b_))
-		return YES;
-
-	// Compute bounding box (WDBezierSegmentGetSimpleBounds)
-	CGPoint min = CGPointMin(seg.a_, seg.out_);
-	CGPoint max = CGPointMax(seg.a_, seg.out_);
-	min = CGPointMin(min, seg.in_);
-	max = CGPointMax(max, seg.in_);
-	min = CGPointMin(min, seg.b_);
-	max = CGPointMax(max, seg.b_);
-
-	// Get bounding box size
-	CGFloat dx = max.x - min.x;
-	CGFloat dy = max.y - min.y;
-
-	return
-	(dx <= tolerance)&&
-	(dy <= tolerance);
+	const CGPoint *P = &seg.a_;
+	if (fabs(P[1].x - P[0].x) > deviceTolerance) return NO;
+	if (fabs(P[1].y - P[0].y) > deviceTolerance) return NO;
+	if (fabs(P[2].x - P[3].x) > deviceTolerance) return NO;
+	if (fabs(P[2].y - P[3].y) > deviceTolerance) return NO;
+	return YES;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -37,6 +37,20 @@ WDBezierSegment WDBezierSegmentMake(WDBezierNode *a, WDBezierNode *b)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static inline CGPoint CGPointInterpolate(CGPoint P1, CGPoint P2, CGFloat r)
+{ return (CGPoint){ P1.x + r * (P2.x - P1.x), P1.y + r * (P2.y - P1.y) }; }
+
+WDBezierSegment
+WDBezierSegmentMakeWithQuadPoints(CGPoint a, CGPoint c, CGPoint b)
+{
+	// Convert to cubic http://fontforge.sourceforge.net/bezier.html
+	return (WDBezierSegment) { a,
+	CGPointInterpolate(a, c, 2.0/3.0),
+	CGPointInterpolate(b, c, 2.0/3.0), b };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 static inline CGPoint CGPointMin(CGPoint P1, CGPoint P2)
 { return (CGPoint){ MIN(P1.x, P2.x), MIN(P1.y, P2.y) }; }
 

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -653,28 +653,18 @@ static inline double _ComputeValueAtT
 
 static inline double WDBezierSegmentComputeX(WDBezierSegment seg, float t)
 {
-	// Get Bezier co-efficients
-	double X0 = seg.a_.x;
-	double X1 = seg.out_.x;
-	double X2 = seg.in_.x;
-	double X3 = seg.b_.x;
-
 	// Compute x coordinate for t
-	return _ComputeValueAtT(X0, X1, X2, X3, t);
+	const CGPoint *P = &seg.a_;
+	return _ComputeValueAtT(P[0].x, P[1].x, P[2].x, P[3].x, t);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 static inline double WDBezierSegmentComputeY(WDBezierSegment seg, float t)
 {
-	// Get Bezier co-efficients
-	double Y0 = seg.a_.y;
-	double Y1 = seg.out_.y;
-	double Y2 = seg.in_.y;
-	double Y3 = seg.b_.y;
-
 	// Compute y coordinate for t
-	return _ComputeValueAtT(Y0, Y1, Y2, Y3, t);
+	const CGPoint *P = &seg.a_;
+	return _ComputeValueAtT(P[0].y, P[1].y, P[2].y, P[3].y, t);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Inkpad-Core/Model/WDBezierSegment.m
+++ b/Inkpad-Core/Model/WDBezierSegment.m
@@ -15,8 +15,8 @@
 
 const float kDefaultFlatness = 1.5;
 
-static CGPoint      *vertices = NULL;
-static NSUInteger   size = 128;
+static CGPoint      *gVertices = NULL;
+static NSUInteger   gSize = 128;
 
 float firstDerivative(float A, float B, float C, float D, float t);
 float secondDerivative(float A, float B, float C, float D, float t);
@@ -497,22 +497,22 @@ CGRect WDBezierSegmentBounds(WDBezierSegment seg)
 {
     NSUInteger  index = 0;
     
-    if (!vertices) {
-        vertices = calloc(sizeof(CGPoint), size);
+    if (!gVertices) {
+        gVertices = calloc(sizeof(CGPoint), gSize);
     }
     
-    WDBezierSegmentFlatten(seg, &vertices, &size, &index);
+    WDBezierSegmentFlatten(seg, &gVertices, &gSize, &index);
     
     float   minX, maxX, minY, maxY;
     
-    minX = maxX = vertices[0].x;
-    minY = maxY = vertices[0].y;
+    minX = maxX = gVertices[0].x;
+    minY = maxY = gVertices[0].y;
     
     for (int i = 1; i < index; i++) {
-        minX = MIN(minX, vertices[i].x);
-        maxX = MAX(maxX, vertices[i].x);
-        minY = MIN(minY, vertices[i].y);
-        maxY = MAX(maxY, vertices[i].y);
+        minX = MIN(minX, gVertices[i].x);
+        maxX = MAX(maxX, gVertices[i].x);
+        minY = MIN(minY, gVertices[i].y);
+        maxY = MAX(maxY, gVertices[i].y);
     }
     
     return CGRectMake(minX, minY, maxX - minX, maxY - minY);

--- a/Inkpad-Core/Model/WDPath.m
+++ b/Inkpad-Core/Model/WDPath.m
@@ -173,7 +173,7 @@ NSString *WDClosedKey = @"WDClosedKey";
     for (int i = 0; i < numNodes-1; i++) {
         WDBezierNode    *a = nodes[i];
         WDBezierNode    *b = nodes[i+1];
-        WDBezierSegment segment = WDBezierSegmentMake(a, b);
+        WDBezierSegment segment = WDBezierSegmentMakeWithNodes(a, b);
         WDBezierSegment L, R;
         
         if (WDBezierSegmentPointDistantFromPoint(segment, [arrowhead insetLength:butt] * scale, arrowTip, &result, &t)) {
@@ -804,7 +804,7 @@ NSString *WDClosedKey = @"WDClosedKey";
             continue;
         }
         
-        seg = WDBezierSegmentMake(prev, node);
+        seg = WDBezierSegmentMakeWithNodes(prev, node);
         if (WDBezierSegmentIntersectsRect(seg, rect)) {
             return YES;
         }
@@ -813,7 +813,7 @@ NSString *WDClosedKey = @"WDClosedKey";
     }
     
     if (self.closed) {
-        seg = WDBezierSegmentMake([nodes_ lastObject], nodes_[0]);
+        seg = WDBezierSegmentMakeWithNodes([nodes_ lastObject], nodes_[0]);
         if (WDBezierSegmentIntersectsRect(seg, rect)) {
             return YES;
         }
@@ -1208,7 +1208,7 @@ NSString *WDClosedKey = @"WDClosedKey";
     for (int i = 1; i < numNodes; i++, segmentIndex ++) {
         curr = nodes_[(i % nodes_.count)];
         
-        segment = WDBezierSegmentMake(prev, curr);
+        segment = WDBezierSegmentMakeWithNodes(prev, curr);
         
         if (!added && WDBezierSegmentFindPointOnSegment(segment, pt, kNodeSelectionTolerance / viewScale, NULL, &t)) {
             WDBezierSegmentSplitAtT(segment,  &segments[segmentIndex], &segments[segmentIndex+1], t);
@@ -1262,7 +1262,7 @@ NSString *WDClosedKey = @"WDClosedKey";
     for (int i = 1; i < numNodes; i++, segmentIndex += 2) {
         curr = nodes_[(i % nodes_.count)];
         
-        segment = WDBezierSegmentMake(prev, curr);
+        segment = WDBezierSegmentMakeWithNodes(prev, curr);
         WDBezierSegmentSplit(segment, &segments[segmentIndex], &segments[segmentIndex+1]);
         
         prev = curr;
@@ -1705,7 +1705,7 @@ NSString *WDClosedKey = @"WDClosedKey";
         prev = nodes[0];
         for (int i = 1; i < nodes.count; i++, prev = curr) {
             curr = nodes[i];
-            segments[i-1] = WDBezierSegmentMake(prev, curr);
+            segments[i-1] = WDBezierSegmentMakeWithNodes(prev, curr);
         }
         
         erasePath = [erasePath pathByFlatteningPath];

--- a/Inkpad-Core/Model/WDTextPath.m
+++ b/Inkpad-Core/Model/WDTextPath.m
@@ -343,7 +343,7 @@ NSString *WDTextPathAlignmentKey = @"WDTextPathAlignmentKey";
     for (int i = 1; i < numNodes; i++) {
         curr = [nodes[(i % nodes.count)] transform:inverse];
         
-        segment = WDBezierSegmentMake(prev, curr);
+        segment = WDBezierSegmentMakeWithNodes(prev, curr);
         length = WDBezierSegmentLength(segment);
         
         if (distance < length) {
@@ -376,7 +376,7 @@ NSString *WDTextPathAlignmentKey = @"WDTextPathAlignmentKey";
     for (int i = 1; i < numNodes; i++) {
         curr = [nodes[(i % nodes.count)] transform:inverse];
         
-        segments[i-1] = WDBezierSegmentMake(prev, curr);
+        segments[i-1] = WDBezierSegmentMakeWithNodes(prev, curr);
         lengths[i-1] = WDBezierSegmentLength(segments[i-1]);
         totalLength += lengths[i-1];
 


### PR DESCRIPTION
Previous version would incorrectly report true in some cases, particularly when:
seg.a_ == seg.b_ and (seg.a_ != seg.in_ or seg.out_ != seg.b_)

Note that there are also cases where the segment may be flat, but can not be approximated by a line between seg.a_ and seg.b_, e.g. all segment's coordinates in one direction are equal

Note also that even CoreGraphics seems to make a mistake. The attached images show a path where seg.a_ == seg.b_ (left) and the same path with same properties on the right where seg.a_ != seg.b_. (Drawn with the new routine). 

![screen shot 2014-01-07 at 10 48 31 am](https://f.cloud.github.com/assets/786628/1857946/2818b48a-7783-11e3-92f5-5d5d633780ed.png)
![screen shot 2014-01-07 at 10 48 51 am](https://f.cloud.github.com/assets/786628/1857949/2d837e32-7783-11e3-8adf-972fae652891.png)
