### PR TITLE
Fix issue with SVG import of viewBox with x & y that are non-zero

### DIFF
--- a/Inkpad-Core/SVG/WDSVGParser.m
+++ b/Inkpad-Core/SVG/WDSVGParser.m
@@ -197,6 +197,7 @@
             state_.viewBoxTransform = [self preserveAspectRatio:preserve withSize:CGSizeMake(w, h) andBounds:state_.viewport];
             state_.viewport = CGRectMake(x, y, w, h);
             state_.transform = CGAffineTransformConcat(state_.viewBoxTransform, state_.transform);
+            state_.transform = CGAffineTransformTranslate(state_.transform, -x, -y);
         }
     } 
 }


### PR DESCRIPTION
When importing an SVG file that has a viewBox with an x or y component then the content is not correctly positioned in the viewport. This change correctly positions the content.

e.g.
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="6.287879in" height="3.750000in" version="1.1" viewBox="150.000000 85.500000 830.000000 495.000000">
